### PR TITLE
feat: 게시글 생성 기능, 게시글 상세 조회 기능 추가

### DIFF
--- a/src/main/java/team/five/lifegram/LifegramApplication.java
+++ b/src/main/java/team/five/lifegram/LifegramApplication.java
@@ -2,9 +2,8 @@ package team.five.lifegram;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@SpringBootApplication
 public class LifegramApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/team/five/lifegram/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/team/five/lifegram/domain/comment/dto/CommentResponseDto.java
@@ -1,0 +1,23 @@
+package team.five.lifegram.domain.comment.dto;
+
+import lombok.Getter;
+import team.five.lifegram.domain.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentResponseDto {
+     private Long commentId;
+     private String commentImgUrl;
+     private String content;
+     private String writer;
+     private LocalDateTime createdAt;
+
+    public CommentResponseDto(Comment comment) {
+        this.commentId = comment.getId();
+        this.commentImgUrl = comment.getUser().getImg_url();
+        this.content = comment.getContent();
+        this.writer = comment.getUser().getUserName();
+        this.createdAt = comment.getCreatedAt();
+    }
+}

--- a/src/main/java/team/five/lifegram/domain/comment/entity/Comment.java
+++ b/src/main/java/team/five/lifegram/domain/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package team.five.lifegram.domain.comment.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CurrentTimestamp;
@@ -27,6 +28,7 @@ public class Comment {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;

--- a/src/main/java/team/five/lifegram/domain/post/controller/PostController.java
+++ b/src/main/java/team/five/lifegram/domain/post/controller/PostController.java
@@ -3,12 +3,12 @@ package team.five.lifegram.domain.post.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import team.five.lifegram.domain.post.dto.DetailPostResponseDto;
 import team.five.lifegram.domain.post.dto.PostResponseDto;
 import team.five.lifegram.domain.post.service.PostService;
+import team.five.lifegram.global.Security.AuthPayload;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +20,16 @@ public class PostController {
     @GetMapping("")
     public Page<PostResponseDto> getPosts(@RequestParam("page") int page, @RequestParam("size") int size) {
         return postService.getPosts(page-1, size);
+    }
+
+    @PostMapping("")
+    public void createPost(@RequestPart String content, @RequestPart String image, @AuthenticationPrincipal AuthPayload authPayload) {
+        Long userId = authPayload.userId();
+        postService.createPost(content, image, userId);
+    }
+
+    @GetMapping("{postId}")
+    public DetailPostResponseDto getDetailPost(@PathVariable Long postId) {
+        return postService.getDetailPost(postId);
     }
 }

--- a/src/main/java/team/five/lifegram/domain/post/dto/DetailPostResponseDto.java
+++ b/src/main/java/team/five/lifegram/domain/post/dto/DetailPostResponseDto.java
@@ -1,14 +1,16 @@
 package team.five.lifegram.domain.post.dto;
 
 import lombok.Getter;
+import team.five.lifegram.domain.comment.dto.CommentResponseDto;
 import team.five.lifegram.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
-public class PostResponseDto {
+public class DetailPostResponseDto {
     private Long postId;
-    private String WriterImgUrl;
+    private String writerImgUrl;
     private String imageUrl;
     private String content;
     private Long likeCount;
@@ -17,10 +19,11 @@ public class PostResponseDto {
     private String writer;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private List<CommentResponseDto> comments;
 
-    public PostResponseDto(Post post) {
+    public DetailPostResponseDto(Post post) {
         this.postId = post.getId();
-        this.WriterImgUrl = post.getUser().getImg_url();
+        this.writerImgUrl = post.getUser().getImg_url();
         this.imageUrl = post.getImage_url();
         this.content = post.getContent();
         this.likeCount = 1L;
@@ -29,5 +32,6 @@ public class PostResponseDto {
         this.writer = post.getUser().getUserName();
         this.createdAt = post.getCreatedAt();
         this.updatedAt = post.getUpdatedAt();
+        this.comments = post.getCommentList().stream().map(CommentResponseDto::new).toList();
     }
 }

--- a/src/main/java/team/five/lifegram/domain/post/entity/Post.java
+++ b/src/main/java/team/five/lifegram/domain/post/entity/Post.java
@@ -1,11 +1,13 @@
 package team.five.lifegram.domain.post.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CurrentTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import team.five.lifegram.domain.comment.entity.Comment;
+import team.five.lifegram.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -20,7 +22,7 @@ public class Post {
     private Long id;
 
     @Column(nullable = false)
-    private String imageUrl;
+    private String image_url;
 
     @Column(length = 1024, nullable = false)
     private String content;
@@ -32,6 +34,18 @@ public class Post {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @JsonIgnore
     @OneToMany(mappedBy = "post")
     private List<Comment> commentList = new ArrayList<>();
+
+    public Post(String image_url, String content, User user) {
+        this.image_url = image_url;
+        this.content = content;
+        this.user = user;
+    }
+
 }

--- a/src/main/java/team/five/lifegram/domain/post/service/PostService.java
+++ b/src/main/java/team/five/lifegram/domain/post/service/PostService.java
@@ -6,21 +6,41 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import team.five.lifegram.domain.post.dto.DetailPostResponseDto;
 import team.five.lifegram.domain.post.dto.PostResponseDto;
 import team.five.lifegram.domain.post.entity.Post;
 import team.five.lifegram.domain.post.repository.PostRepository;
+import team.five.lifegram.domain.user.entity.User;
+import team.five.lifegram.domain.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
     public Page<PostResponseDto> getPosts(int page, int size) {
         Sort.Direction direction = Sort.Direction.DESC;
         Sort sort = Sort.by(direction, "id");
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<Post> posts = postRepository.findAll(pageable);
         return posts.map(PostResponseDto::new);
+    }
 
+    public void createPost(String content, String image, Long userId) {
+        //이미지 업로드 과정
+
+
+        String image_url = image;
+        User user = userRepository.findById(userId).orElseThrow(()->
+                new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+        Post post = new Post(image_url, content, user);
+        postRepository.save(post);
+    }
+
+    public DetailPostResponseDto getDetailPost(Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(()->
+                new IllegalArgumentException("게시글이 존재하지 않습니다."));
+        return new DetailPostResponseDto(post);
     }
 }


### PR DESCRIPTION
### 개요

게시글 생성 기능, 게시글 상세 조회 기능 추가

### 작업 상황

게시글 상세조회를 위한 DetailPostResponseDto 작성, 상세 조회시 댓글을 위한 CommentResponseDto 작성, 게시글 상세 조회시 무한 참조를 방지하기 위한 @JsonIgnore 추가. 프론트 요청으로 게시글 상세 조회시 writerImgUrl, commentImgUrl추가
