### PR TITLE
update: 게시글 작성시 글자수 2200으로 변경

### DIFF
--- a/src/main/java/team/five/lifegram/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/team/five/lifegram/domain/post/dto/PostRequestDto.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @Getter
 public class PostRequestDto {
     @NotBlank
-    @Size(max = 1024)
+    @Size(max = 2200)
     private String content;
 }

--- a/src/main/java/team/five/lifegram/domain/post/entity/Post.java
+++ b/src/main/java/team/five/lifegram/domain/post/entity/Post.java
@@ -25,7 +25,7 @@ public class Post {
     @Column(nullable = false)
     private String image_url;
 
-    @Column(length = 1024, nullable = false)
+    @Column(length = 2200, nullable = false)
     private String content;
 
     @CurrentTimestamp


### PR DESCRIPTION
### 개요

게시글 작성시 글자수 2200으로 변경

### 작업 상황

인스타그램의 게시글 내용 글자수 제한대로 2200으로 변경