### PR TITLE
feat: 유저 검색 기능 구현

### DIFF
--- a/src/main/java/team/five/lifegram/domain/user/controller/UserController.java
+++ b/src/main/java/team/five/lifegram/domain/user/controller/UserController.java
@@ -5,8 +5,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import team.five.lifegram.domain.user.dto.UserProfileResponseDto;
+import team.five.lifegram.domain.user.dto.UserProfileSearchResponseDto;
 import team.five.lifegram.domain.user.service.UserService;
 import team.five.lifegram.global.Security.AuthPayload;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +28,11 @@ public class UserController {
     public void updateUserProfile(@RequestPart(name = "image") MultipartFile image, @AuthenticationPrincipal AuthPayload authPayload) {
         Long userId = authPayload.userId();
         userService.updateUserProfile(image, userId);
+    }
+
+    @GetMapping("/search")
+    public List<UserProfileSearchResponseDto> findUser(@RequestParam String qName, @AuthenticationPrincipal AuthPayload authPayload) {
+        Long userId = authPayload.userId();
+        return userService.findUser(qName, userId);
     }
 }

--- a/src/main/java/team/five/lifegram/domain/user/dto/UserProfileSearchResponseDto.java
+++ b/src/main/java/team/five/lifegram/domain/user/dto/UserProfileSearchResponseDto.java
@@ -1,0 +1,24 @@
+package team.five.lifegram.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import team.five.lifegram.domain.user.entity.User;
+import team.five.lifegram.global.util.HttpUtils;
+
+@Getter
+@Builder
+public class UserProfileSearchResponseDto {
+    private Long userId;
+    private String userName;
+    private String profileImgUrl;
+    private boolean isFollowing;
+
+    public static UserProfileSearchResponseDto of(User user, boolean isFollowing){
+        return UserProfileSearchResponseDto.builder()
+                .userId(user.getId())
+                .userName(user.getUserName())
+                .profileImgUrl(HttpUtils.parseS3Url("images/profile",user.getImg_url()))
+                .isFollowing(isFollowing)
+                .build();
+    }
+}

--- a/src/main/java/team/five/lifegram/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/five/lifegram/domain/user/repository/UserRepository.java
@@ -3,8 +3,10 @@ package team.five.lifegram.domain.user.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.five.lifegram.domain.user.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    List<User> findByUserNameContaining(String qName);
 }

--- a/src/main/java/team/five/lifegram/domain/user/service/UserService.java
+++ b/src/main/java/team/five/lifegram/domain/user/service/UserService.java
@@ -6,9 +6,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import team.five.lifegram.domain.post.repository.PostRepository;
 import team.five.lifegram.domain.user.dto.UserProfileResponseDto;
+import team.five.lifegram.domain.user.dto.UserProfileSearchResponseDto;
 import team.five.lifegram.domain.user.entity.User;
 import team.five.lifegram.domain.user.repository.UserRepository;
 import team.five.lifegram.global.imageUpload.S3Upload;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -41,5 +44,13 @@ public class UserService {
         }else {
             throw new IllegalArgumentException("이미지 없이 프로필 사진을 수정할 수 없습니다.");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserProfileSearchResponseDto> findUser(String qName, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(()->
+                new IllegalArgumentException("존재하지 않는 사용자 입니다."));
+        List<User> users = userRepository.findByUserNameContaining(qName);
+        return users.stream().map((finduser) -> UserProfileSearchResponseDto.of(finduser, false)).toList();
     }
 }


### PR DESCRIPTION
### 개요

유저 검색 기능 구현

### 작업 상황

검색어와 함께 요청 시 검색어가 포함된 userName을 가진 유저의 userId, userName, profileImgUrl 그리고 요청자와 팔로잉 유무를 
나타내는 following을 dto에 담아 List형태로 반환

