### PR TITLE
test: 팔로우 기능과 네 팔로우 목록 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ task securityInfo() {
 
 tasks.named('test') {
     useJUnitPlatform()
-//    finalizedBy jacocoTestReport
+    finalizedBy jacocoTestReport
 }
 
 jacoco {

--- a/src/test/java/team/five/lifegram/domain/user/service/UserServiceTest.java
+++ b/src/test/java/team/five/lifegram/domain/user/service/UserServiceTest.java
@@ -9,28 +9,24 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 import team.five.lifegram.domain.like.repository.LikeRepository;
-import team.five.lifegram.domain.post.dto.DetailPostResponseDto;
-import team.five.lifegram.domain.post.entity.Post;
 import team.five.lifegram.domain.post.repository.PostRepository;
-import team.five.lifegram.domain.post.service.PostService;
 import team.five.lifegram.domain.user.dto.UserProfileResponseDto;
+import team.five.lifegram.domain.user.entity.Follow;
 import team.five.lifegram.domain.user.entity.User;
+import team.five.lifegram.domain.user.repository.FollowRepository;
 import team.five.lifegram.domain.user.repository.UserRepository;
 import team.five.lifegram.global.imageUpload.S3Upload;
+import team.five.lifegram.global.util.HttpUtils;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -43,6 +39,9 @@ class UserServiceTest {
 
     @Mock
     LikeRepository likeRepository;
+
+    @Mock
+    FollowRepository followRepository;
 
     @Mock
     S3Upload s3Upload;
@@ -74,13 +73,13 @@ class UserServiceTest {
                     .id(userId)
                     .build();
             given(userRepository.findById(userId)).willReturn(Optional.ofNullable(user));
-            UserService userService = new UserService(postRepository, userRepository, s3Upload);
+            UserService userService = new UserService(postRepository, userRepository, followRepository, s3Upload);
 
             // when
             UserProfileResponseDto userProfile = userService.getUserProfile(userId);
 
             // then
-            assertEquals(userProfile.getProfileImgUrl(), user.getImg_url());
+            assertEquals(userProfile.getProfileImgUrl(), HttpUtils.parseS3Url("images/profile",user.getImg_url()));
         }
 
         @Test
@@ -88,7 +87,7 @@ class UserServiceTest {
         void getUserProfileNoUserTest() {
             // given
             Long userId = 1L;
-            UserService userService = new UserService(postRepository, userRepository, s3Upload);
+            UserService userService = new UserService(postRepository, userRepository, followRepository, s3Upload);
 
             // when
             Exception exception = assertThrows(IllegalArgumentException.class, ()->
@@ -97,5 +96,135 @@ class UserServiceTest {
             // then
             assertEquals("존재하지 않는 사용자 입니다.", exception.getMessage());
         }
+    }
+
+    @Nested
+    @DisplayName("팔로우 중인 유저")
+    class FindFollowingUser {
+
+        @Test
+        @DisplayName("FindFollowingUser 성공 테스트")
+        void findFollowingUserSuccessTest() {
+            Long userId = 1L;
+            User user = mock(User.class);
+            given(userRepository.findById(userId)).willReturn(Optional.ofNullable(user));
+
+            UserService userService = new UserService(postRepository,userRepository,followRepository,s3Upload);
+            List<Follow> follows = new ArrayList<>();
+            Follow follow = Follow.builder()
+                    .fromUser(user)
+                    .toUser(user)
+                    .build();
+            follows.add(follow);
+            given(user.getFollowing()).willReturn(follows);
+
+            userService.findFollowingUser(userId);
+        }
+
+        @Test
+        @DisplayName("FindFollowingUser 해당 userId유저 없음 테스트")
+        void findFollowingUserNoUserTest() {
+            //given
+            Long userId = 1L;
+            UserService userService = new UserService(postRepository,userRepository,followRepository,s3Upload);
+
+            //when
+            IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () ->
+                    userService.findFollowingUser(userId));
+
+            //then
+            assertEquals("존재하지 않는 사용자 입니다.", illegalArgumentException.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("followUser")
+    class FollowUser {
+
+        @Test
+        @DisplayName("FollowUser 성공 새로운 팔로우 테스트")
+        void followUserNewFollowSuccessTest() {
+            // given
+            Long fromUserId = 1L;
+            Long toUserId = 2L;
+
+            User fromUser = mock(User.class);
+            given(userRepository.findById(fromUserId)).willReturn(Optional.ofNullable(fromUser));
+            User toUser = mock(User.class);
+            given(userRepository.findById(toUserId)).willReturn(Optional.ofNullable(toUser));
+
+            Follow follow = null;
+            given(followRepository.findByFromUserAndToUser(fromUser, toUser)).willReturn(Optional.ofNullable(follow));
+
+            UserService userService = new UserService(postRepository, userRepository, followRepository, s3Upload);
+
+            // when
+            userService.followUser(fromUserId, toUserId);
+
+        }
+
+        @Test
+        @DisplayName("FollowUser 성공 팔로우 취소 테스트")
+        void followUserCancelFollowSuccessTest() {
+            // given
+            Long fromUserId = 1L;
+            Long toUserId = 2L;
+
+            User fromUser = mock(User.class);
+            given(userRepository.findById(fromUserId)).willReturn(Optional.ofNullable(fromUser));
+            User toUser = mock(User.class);
+            given(userRepository.findById(toUserId)).willReturn(Optional.ofNullable(toUser));
+
+            Follow follow = Follow.builder()
+                    .fromUser(fromUser)
+                    .toUser(toUser)
+                    .build();
+            Optional<Follow> optionalFollow = Optional.of(follow);
+            given(followRepository.findByFromUserAndToUser(fromUser, toUser)).willReturn(optionalFollow);
+
+            UserService userService = new UserService(postRepository, userRepository, followRepository, s3Upload);
+
+            // when
+            userService.followUser(fromUserId, toUserId);
+
+        }
+
+        @Test
+        @DisplayName("FollowUser NoFromUser Test")
+        void followUserNoFromUserTest() {
+            // given
+            Long fromUserId = 1L;
+            Long toUserId = 2L;
+
+            UserService userService = new UserService(postRepository, userRepository, followRepository, s3Upload);
+
+            // when
+            IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () ->
+                    userService.followUser(fromUserId, toUserId));
+
+            // then
+            assertEquals("다시 시도해 주세요", illegalArgumentException.getMessage());
+        }
+
+        @Test
+        @DisplayName("FollowUser NoToUser Test")
+        void followUserNoToUserTest() {
+            // given
+            Long fromUserId = 1L;
+            Long toUserId = 2L;
+
+            User fromUser = mock(User.class);
+            given(userRepository.findById(fromUserId)).willReturn(Optional.ofNullable(fromUser));
+
+            UserService userService = new UserService(postRepository, userRepository, followRepository, s3Upload);
+
+            // when
+            IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () ->
+                    userService.followUser(fromUserId, toUserId));
+
+            // then
+            assertEquals("팔로우 하려는 유저가 존재하지 않습니다.", illegalArgumentException.getMessage());
+        }
+
     }
 }


### PR DESCRIPTION
### 개요

팔로우 기능과 나의 팔로우 목록 테스트 코드 작성

### 작업상황

팔로우 기능 팔로우, 팔로우 취소 성공케이스, 해당 fromUserId 유저 없음 실패 케이스 , 해당 toUserId 유저 없음 실패 케이스 테스트 코드 작성
나의 팔로우 목록 성공 케이스, 해당 userId의 유저 없음 실패 케이스 테스트 코드 작성